### PR TITLE
Minor readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ full testing workflow.
 
 * In `project.clj` add `clj-grpc` to dependencies:
 ```clojure
-[clj-grpc "0.1.0"]
+[clj-grpc "0.1.2"]
 ```
 
 * Configure `lein-protoc` plugin. Please note, that until original `protoc` is fixed, for Clojure 1.9 you have to use 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ full testing workflow.
 ;; decide which version of protoc and grpc-java to use
 :protoc-version "3.10.0"
 :protoc-grpc {:version "1.25.0"}
-:protoc-source-paths ["src/proto"] ;; where to look for `.proto` files
+:proto-source-paths ["src/proto"] ;; where to look for `.proto` files
 :proto-target-path "target/generated-sources/protobuf" ;; where should protoc put generated sources
 :java-source-paths [... "target/generated-sources/protobuf"] ;; point java compiler to newly generated sources
 ```
 
-* Create `example.proto` file in `src/protoc`:
+* Create `example.proto` file in `src/proto`:
 ```proto
 syntax = "proto3";
 


### PR DESCRIPTION
Minor typos fixes in README.md:

`:protoc-source-paths` -> `:proto-source-paths`

```
$ lein protoc --help
Compiles Google Protocol Buffer proto files to Java Sources.

  The following options are available and should be configured in the
  project.clj:

    :protoc-version     :: the Protocol Buffers Compiler version to use.

    :proto-source-paths :: vector of absolute paths or paths relative to
                           the project root that contain the .proto files
                           to be compiled. Defaults to `["src/proto"]`

    :proto-target-path  :: the absolute path or path relative to the project
                           root where the sources should be generated. Defaults
                           to `${target-path}/generated-sources/protobuf`

    :protoc-grpc        :: true (or empty map) to generate interfaces for gRPC
                           service definitions with default settings. Can
                           optionally provide a map with the following configs:
                             :version     - version number for gRPC codegen.
                             :target-path - absolute path or path relative to
                                            the project root where the sources
                                            should be generated. Defaults to
                                            the `:proto-target-path`
                           Defaults to `false`.

    :protoc-timeout     :: timeout value in seconds for the compilation process
                           Defaults to 60

```

and `src/protoc` -> `src/proto`, to make it consistent

`[clj-grpc "0.1.0"]` -> `[clj-grpc "0.1.2"]`